### PR TITLE
Bumped to Czkawka 5.0.2. Added support for HEIC.

### DIFF
--- a/appdefs.xml
+++ b/appdefs.xml
@@ -30,6 +30,13 @@ unnecessary files from your computer.
     <!-- Changelog of the application. -->
     <history>
       <release>
+        <version>1.8.0</version>
+        <date>2022-11-18</date>
+        <change>Updated Czkawka to version 5.0.2.</change>
+        <change>Now using baseimage version 4.1.6, based on Alpine 3.16, which brings the following change:</change>
+        <change level="2">Updated installed packages to get latest security fixes.</change>
+      </release>
+      <release>
         <version>1.7.0</version>
         <date>2022-04-24</date>
         <change>Updated Czkawka to version 4.1.0.</change>

--- a/rootfs/etc/cont-init.d/55-czkawka.sh
+++ b/rootfs/etc/cont-init.d/55-czkawka.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv sh
+#!/bin/sh
 
 set -e # Exit immediately if a command exits with a non-zero status.
 set -u # Treat unset variables as an error.

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv sh
+#!/bin/sh
 cd /storage
 exec /usr/bin/czkawka_gui


### PR DESCRIPTION
Update to the `baseimage-gui:alpine-3.16-v4.1.5` base image, including the required changes to variables, script names, removing `with-contenv`, managing window sizes, etc. Adds support for GTK4.0. Adds support for HEIC. Resolves #9 .