### PR TITLE
Update Czkawka to 7.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 ARG DOCKER_IMAGE_VERSION=
 
 # Define software versions.
-ARG CZKAWKA_VERSION=6.1.0
+ARG CZKAWKA_VERSION=7.0.0
 
 # Define software download URLs.
 ARG CZKAWKA_URL=https://github.com/qarmin/czkawka/archive/${CZKAWKA_VERSION}.tar.gz

--- a/src/czkawka/disable_trash.patch
+++ b/src/czkawka/disable_trash.patch
@@ -39,12 +39,12 @@
  
 --- a/czkawka_gui/src/saving_loading.rs	2022-11-30 19:05:16.727908825 -0500
 +++ b/czkawka_gui/src/saving_loading.rs	2022-11-30 19:18:20.654609426 -0500
-@@ -738,7 +738,7 @@
-     let hide_hard_links: bool = loaded_entries.get_bool(hashmap_ls.get(&LoadText::HideHardLinks).unwrap().clone(), DEFAULT_HIDE_HARD_LINKS);
-     let use_cache: bool = loaded_entries.get_bool(hashmap_ls.get(&LoadText::UseCache).unwrap().clone(), DEFAULT_USE_CACHE);
-     let use_json_cache: bool = loaded_entries.get_bool(hashmap_ls.get(&LoadText::UseJsonCacheFile).unwrap().clone(), DEFAULT_SAVE_ALSO_AS_JSON);
--    let use_trash: bool = loaded_entries.get_bool(hashmap_ls.get(&LoadText::DeleteToTrash).unwrap().clone(), DEFAULT_USE_TRASH);
-+    let use_trash: bool = false; //loaded_entries.get_bool(hashmap_ls.get(&LoadText::DeleteToTrash).unwrap().clone(), DEFAULT_USE_TRASH);
-     let ignore_other_fs: bool = loaded_entries.get_bool(
-         hashmap_ls.get(&LoadText::GeneralIgnoreOtherFilesystems).unwrap().clone(),
-         DEFAULT_GENERAL_IGNORE_OTHER_FILESYSTEMS,
+@@ -644,7 +644,7 @@ pub fn load_configuration(
+     let hide_hard_links: bool = loaded_entries.get_bool(hashmap_ls[&LoadText::HideHardLinks].clone(), DEFAULT_HIDE_HARD_LINKS);
+     let use_cache: bool = loaded_entries.get_bool(hashmap_ls[&LoadText::UseCache].clone(), DEFAULT_USE_CACHE);
+     let use_json_cache: bool = loaded_entries.get_bool(hashmap_ls[&LoadText::UseJsonCacheFile].clone(), DEFAULT_SAVE_ALSO_AS_JSON);
+-    let use_trash: bool = loaded_entries.get_bool(hashmap_ls[&LoadText::DeleteToTrash].clone(), DEFAULT_USE_TRASH);
++    let use_trash: bool = false;
+     let ignore_other_fs: bool = loaded_entries.get_bool(hashmap_ls[&LoadText::GeneralIgnoreOtherFilesystems].clone(), DEFAULT_GENERAL_IGNORE_OTHER_FILESYSTEMS);
+     let delete_outdated_cache_duplicates: bool = loaded_entries.get_bool(
+         hashmap_ls[&LoadText::DuplicateDeleteOutdatedCacheEntries].clone(),


### PR DESCRIPTION
Warning: Upgrading to the newest version makes all the old cache files invalid, because they're not compatible with this version.