### PR TITLE
Use `ffplay` as Video Playback Application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN add-pkg \
         dbus-x11 \
         mesa-dri-gallium \
         ffmpeg \
+        ffplay \
         && \
     # Save some space by removing unused DRI drivers.
     find /usr/lib/xorg/modules/dri/ -type f ! -name swrast_dri.so ! -name libgallium_dri.so -exec echo "Removing {}..." ';' -delete


### PR DESCRIPTION
Resolves https://github.com/jlesage/docker-czkawka/issues/32

Executing in the current master image:
```sh
/tmp # gio open /storage/video.mp4
/tmp # echo $?
127

gio mime video/mp4
No default applications for “video/mp4”
```

^ Seems like there's just no application setup to handle video playback in the image. 

I'm only assuming that `ffplay` is desired to be the application used to open videos because of the installation of `ffmpeg` (which includes `ffplay` on most systems).

Regardless, I can confirm this allows video playback from the video search. 
