### PR TITLE
Fix Video Playback

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN add-pkg \
         libxkbcommon-x11 \
         # Needed to edit krokiet config.
         jq \
+        mesa-dri-gallium \
         moreutils \
         # For the file dialog support (via XDG Desktop Portal backend) of krokiet.
         # https://lib.rs/crates/rfd


### PR DESCRIPTION
Addresses https://github.com/jlesage/docker-czkawka/issues/44

---

As of  [25.06.1](https://github.com/jlesage/docker-czkawka/compare/v25.04.1...v25.06.1) video playback doesn't work:

```sh
ffplay /storage/test.mp4
ffplay version 6.1.1 Copyright (c) 2003-2023 the FFmpeg developers
  built with gcc 13.2.1 (Alpine 13.2.1_git20240309) 20240309
  configuration: --prefix=/usr --disable-librtmp --disable-lzma --disable-static --disable-stripping --enable-avfilter --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libdav1d --enable-libdrm --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-libmp3lame --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librist --enable-libsoxr --enable-libsrt --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-lto=auto --enable-lv2 --enable-openssl --enable-pic --enable-postproc --enable-pthreads --enable-shared --enable-vaapi --enable-vdpau --enable-version3 --enable-vulkan --optflags=-O3 --enable-libjxl --enable-libsvtav1 --enable-libvpl
  libavutil      58. 29.100 / 58. 29.100
  libavcodec     60. 31.102 / 60. 31.102
  libavformat    60. 16.100 / 60. 16.100
  libavdevice    60.  3.100 / 60.  3.100
  libavfilter     9. 12.100 /  9. 12.100
  libswscale      7.  5.100 /  7.  5.100
  libswresample   4. 12.100 /  4. 12.100
  libpostproc    57.  3.100 / 57.  3.100
XDG_RUNTIME_DIR (/tmp/run/user/app) is not owned by us (uid 0), but by uid 1000! (This could e.g. happen if you try to connect to a non-root PulseAudio as a root user, over the native protocol. Don't do that.)
MESA-LOADER: failed to open zink: Error loading shared library /usr/lib/xorg/modules/dri/zink_dri.so: No such file or directory (search paths /usr/lib/xorg/modules/dri, suffix _dri)
MESA-LOADER: failed to open swrast: Error loading shared library /usr/lib/xorg/modules/dri/swrast_dri.so: No such file or directory (search paths /usr/lib/xorg/modules/dri, suffix _dri)
X Error of failed request:  BadValue (integer parameter out of range for operation)
  Major opcode of failed request:  147 (GLX)
  Minor opcode of failed request:  3 (X_GLXCreateContext)
  Value in failed request:  0x0
  Serial number of failed request:  141
  Current serial number in output stream:  142
```

From the output of running ffplay directly, it seems like some drivers are missing. Installing 'mesa-dri-gallium' in the image resolves the issue. This package was removed from this Dockerfile a while back: https://github.com/jlesage/docker-czkawka/compare/v24.05.1...v24.07.1 I'm not too familiar with the base image, so if its preferred to solve it there that's cool as well @jlesage

```sh
diffoci diff jlesage/baseimage-gui:alpine-3.20-v4.7.1 jlesage/baseimage-gui:alpine-3.20-v4.8.0 | grep swrast_dri
INFO[0000] Target platforms: [linux/amd64]
WARN[0000] Layer length mismatch (35 vs 11), squashing for comparison (EXPERIMENTAL)
Layer    ctx:/manifests-0/layer                                                             name "opt/base/lib/dri/swrast_dri.so" only appears in input 1
Layer    ctx:/manifests-0/layer                                                             name "opt/base/lib/dri/kms_swrast_dri.so" only appears in input 1
```
